### PR TITLE
Windows testing

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -2,10 +2,12 @@ filter:
   excluded_paths:
     - tests/*
 
+checks:
+  php:
+    excluded_dependencies:
+      - ext-com_dotnet
+
 build:
-  dependencies:
-    override:
-      - yes | pecl install com_dotnet
   nodes:
     analysis:
       tests:

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -12,5 +12,5 @@ build:
     analysis:
       tests:
         override:
-          - php ./vendor/bin/phpunit --configuration phpunit.xml --exlude-group uses_real_com
+          - php ./vendor/bin/phpunit --configuration phpunit.xml --exclude-group uses_real_com
           - php-scrutinizer-run

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -2,13 +2,10 @@ filter:
   excluded_paths:
     - tests/*
 
-checks:
-  php:
-    excluded_dependencies:
-      - ext-com_dotnet
-      - com_dotnet
-
 build:
+  dependencies:
+    override:
+      - true
   nodes:
     analysis:
       tests:

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -7,11 +7,9 @@ build:
     override:
       -
         command: composer install --ignore-platform-reqs --no-interaction --prefer-dist --no-suggest
-  tests:
-    override:
-      - vendor/bin/phpunit --configuration phpunit.xml --exclude-group uses_real_com
   nodes:
     analysis:
       tests:
         override:
+          - command: vendor/bin/phpunit --configuration phpunit.xml --exclude-group uses_real_com
           - php-scrutinizer-run

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -6,6 +6,7 @@ checks:
   php:
     excluded_dependencies:
       - ext-com_dotnet
+      - com_dotnet
 
 build:
   nodes:

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -7,6 +7,10 @@ build:
     override:
       -
         command: composer install --ignore-platform-reqs --no-interaction --prefer-dist --no-suggest
+  tests:
+    override:
+      - command: vendor/bin/phpunit --configuration phpunit.xml --exclude-group uses_real_com
+      - php-scrutinizer-run
   nodes:
     analysis:
       tests:

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -5,10 +5,12 @@ filter:
 build:
   dependencies:
     override:
-      - true
+      -
+        command: composer install --ignore-platform-reqs --no-interaction --prefer-stable --prefer-dist --no-suggest
   nodes:
     analysis:
       tests:
         override:
-          - phpunit --configuration phpunit.xml --exclude-group uses_real_com
+          -
+            command: vendor/bin/phpunit --configuration phpunit.xml --exclude-group uses_real_com
           - php-scrutinizer-run

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -10,5 +10,5 @@ build:
     analysis:
       tests:
         override:
-          - php ./vendor/bin/phpunit --configuration phpunit.xml --exclude-group uses_real_com
+          - phpunit --configuration phpunit.xml --exclude-group uses_real_com
           - php-scrutinizer-run

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -15,5 +15,4 @@ build:
     analysis:
       tests:
         override:
-          - command: vendor/bin/phpunit --configuration phpunit.xml --exclude-group uses_real_com
           - php-scrutinizer-run

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -6,7 +6,7 @@ build:
   dependencies:
     override:
       -
-        command: composer install --ignore-platform-reqs --no-interaction --prefer-stable --prefer-dist --no-suggest
+        command: composer install --ignore-platform-reqs --no-interaction --prefer-dist --no-suggest
   nodes:
     analysis:
       tests:

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -3,8 +3,12 @@ filter:
     - tests/*
 
 build:
+  dependencies:
+    override:
+      - yes | pecl install com_dotnet
   nodes:
     analysis:
       tests:
         override:
+          - php ./vendor/bin/phpunit --configuration phpunit.xml --exlude-group uses_real_com
           - php-scrutinizer-run

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -7,10 +7,11 @@ build:
     override:
       -
         command: composer install --ignore-platform-reqs --no-interaction --prefer-dist --no-suggest
+  tests:
+    override:
+      - vendor/bin/phpunit --configuration phpunit.xml --exclude-group uses_real_com
   nodes:
     analysis:
       tests:
         override:
-          -
-            command: vendor/bin/phpunit --configuration phpunit.xml --exclude-group uses_real_com
           - php-scrutinizer-run

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_install:
   - echo "extension=php_ftp.dll" >> /c/tools/$PHP_DIR/php.ini
   - echo "extension=php_com_dotnet.dll" >> /c/tools/$PHP_DIR/php.ini
   - echo "memory_limit=256M" >> /c/tools/$PHP_DIR/php.ini
-  - choco install composer --ia '"/DEV=c:\tools /PHP=c:\tools\"':$PHP_DIR
+  - choco install composer /DEV=/c/tools /PHP=/c/tools/$PHP_DIR
   - composer || true
   - travis_retry wget https://curl.haxx.se/ca/cacert.pem -O /c/tools/cacert.pem -q
   - echo "curl.cainfo=C:\tools\cacert.pem" >> /c/tools/$PHP_DIR/php.ini

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,12 +24,12 @@ before_install:
   - echo "extension=php_ftp.dll" >> /c/tools/$PHP_DIR/php.ini
   - echo "extension=php_com_dotnet.dll" >> /c/tools/$PHP_DIR/php.ini
   - echo "memory_limit=256M" >> /c/tools/$PHP_DIR/php.ini
-  - wget https://xdebug.org/files/php_xdebug-2.8.0beta1-7.2-vc15-nts-x86_64.dll -O /c/tools/$PHP_DIR/ext/xdebug.dll -q
-#  - echo "zend_extension=xdebug.dll" >> /c/tools/$PHP_DIR/php.ini
 #  - choco install composer
 #  - phpenv config-rm xdebug.ini || true
   - wget https://raw.githubusercontent.com/composer/getcomposer.org/d3e09029468023aa4e9dcd165e9b6f43df0a9999/web/installer -O - -q | php --
   - travis_retry php composer.phar self-update
+  - wget https://xdebug.org/files/php_xdebug-2.8.0beta1-7.2-vc15-nts-x86_64.dll -O /c/tools/$PHP_DIR/ext/xdebug.dll -q
+  - echo "zend_extension=xdebug.dll" >> /c/tools/$PHP_DIR/php.ini
 #  - travis_retry composer self-update
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_install:
   - echo "extension=php_ftp.dll" >> /c/tools/$PHP_DIR/php.ini
   - echo "extension=php_com_dotnet.dll" >> /c/tools/$PHP_DIR/php.ini
   - echo "memory_limit=256M" >> /c/tools/$PHP_DIR/php.ini
-  - choco install composer
+  - choco install composer /DEV=/c/tools/composer
   - export PATH=/c/tools/composer:$PATH;
   - composer || true
   - travis_retry wget https://curl.haxx.se/ca/cacert.pem -O /c/tools/cacert.pem -q

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ before_install:
   - echo "extension=php_ftp.dll" >> /c/tools/$PHP_DIR/php.ini
   - echo "extension=php_com_dotnet.dll" >> /c/tools/$PHP_DIR/php.ini
   - echo "memory_limit=256M" >> /c/tools/$PHP_DIR/php.ini
+  - get https://raw.githubusercontent.com/composer/getcomposer.org/d3e09029468023aa4e9dcd165e9b6f43df0a9999/web/installer -O - -q | php --
   - travis_retry php composer.phar self-update
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,19 +27,19 @@ cache:
 before_install:
   - choco install php --version $PHP_VERSION -y;
   - export PATH=/c/tools/$PHP_DIR:$PATH;
-  - echo 'extension_dir="ext"' >> /c/tools/$PHP_DIR/php.ini
+  - echo 'extension_dir="ext"' >> /c/tools/$PHP_DIR/php.ini;
   - echo "extension=php_openssl.dll" >> /c/tools/$PHP_DIR/php.ini;
   - echo "extension=php_curl.dll" >> /c/tools/$PHP_DIR/php.ini;
-  - echo "extension=php_mbstring.dll" >> /c/tools/$PHP_DIR/php.ini
-  - echo "extension=php_pdo_mysql.dll" >> /c/tools/$PHP_DIR/php.ini
-  - echo "extension=php_pdo_sqlite.dll" >> /c/tools/$PHP_DIR/php.ini
-  - echo "extension=php_fileinfo.dll" >> /c/tools/$PHP_DIR/php.ini
-  - echo "extension=php_gd2.dll" >> /c/tools/$PHP_DIR/php.ini
-  - echo "extension=php_ftp.dll" >> /c/tools/$PHP_DIR/php.ini
-  - echo "extension=php_com_dotnet.dll" >> /c/tools/$PHP_DIR/php.ini
-  - echo "memory_limit=256M" >> /c/tools/$PHP_DIR/php.ini
-  - choco install composer /DEV=/c/tools /PHP=/c/tools/$PHP_DIR
-  - composer || true
+  - echo "extension=php_mbstring.dll" >> /c/tools/$PHP_DIR/php.ini;
+  - echo "extension=php_pdo_mysql.dll" >> /c/tools/$PHP_DIR/php.ini;
+  - echo "extension=php_pdo_sqlite.dll" >> /c/tools/$PHP_DIR/php.ini;
+  - echo "extension=php_fileinfo.dll" >> /c/tools/$PHP_DIR/php.ini;
+  - echo "extension=php_gd2.dll" >> /c/tools/$PHP_DIR/php.ini;
+  - echo "extension=php_ftp.dll" >> /c/tools/$PHP_DIR/php.ini;
+  - echo "extension=php_com_dotnet.dll" >> /c/tools/$PHP_DIR/php.ini;
+  - echo "memory_limit=256M" >> /c/tools/$PHP_DIR/php.ini;
+  - choco install composer '"/DEV=c:/tools /PHP="'/c/tools/$PHP_DIR;
+  - composer || true;
   - travis_retry wget https://curl.haxx.se/ca/cacert.pem -O /c/tools/cacert.pem -q
   - echo "curl.cainfo=C:\tools\cacert.pem" >> /c/tools/$PHP_DIR/php.ini
   - travis_retry wget https://raw.githubusercontent.com/composer/getcomposer.org/d3e09029468023aa4e9dcd165e9b6f43df0a9999/web/installer -O - -q | php --

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,5 +50,5 @@ install:
 script: ./vendor/bin/phpunit --coverage-clover=/c/tools/$PHP_DIR/coverage.clover
 
 after_script:
-  - travis_retry wget https://scrutinizer-ci.com/ocular.phar
+  - travis_retry wget https://github.com/scrutinizer-ci/ocular/releases/download/1.5.2/ocular.phar
   - php ocular.phar code-coverage:upload --format=php-clover /c/tools/$PHP_DIR/coverage.clover 2>&1

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ before_install:
   - echo "extension=php_ftp.dll" >> /c/tools/$PHP_DIR/php.ini
   - echo "extension=php_com_dotnet.dll" >> /c/tools/$PHP_DIR/php.ini
   - echo "memory_limit=256M" >> /c/tools/$PHP_DIR/php.ini
+  - phpenv config-rm xdebug.ini || true
   - wget https://raw.githubusercontent.com/composer/getcomposer.org/d3e09029468023aa4e9dcd165e9b6f43df0a9999/web/installer -O - -q | php --
   - travis_retry php composer.phar self-update
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,26 +40,23 @@ before_install:
   - echo "extension=php_ftp.dll" >> /c/tools/$PHP_DIR/php.ini;
   - echo "extension=php_com_dotnet.dll" >> /c/tools/$PHP_DIR/php.ini;
   - echo "memory_limit=256M" >> /c/tools/$PHP_DIR/php.ini;
+  # Download CA Bundle and update configuration
+  - travis_retry wget https://curl.haxx.se/ca/cacert.pem -O /c/tools/cacert.pem -q;
+  - echo "curl.cainfo=C:\tools\cacert.pem" >> /c/tools/$PHP_DIR/php.ini;
   # Install Composer and modify PATH
   - choco install composer -i;
   - export PATH=/c/ProgramData/ComposerSetup/bin:$PATH;
-  # Download CA Bundle and update configuration
-  - travis_retry wget https://curl.haxx.se/ca/cacert.pem -O /c/tools/cacert.pem -q
-  - echo "curl.cainfo=C:\tools\cacert.pem" >> /c/tools/$PHP_DIR/php.ini
-#  - travis_retry wget https://raw.githubusercontent.com/composer/getcomposer.org/d3e09029468023aa4e9dcd165e9b6f43df0a9999/web/installer -O - -q | php --
   # Make sure composer is up-to-date
   - travis_retry composer self-update
-#  - travis_retry php composer.phar self-update
   # Download appropriate XDebug and modify configuration
-  - travis_retry wget $XDEBUG -O /c/tools/$PHP_DIR/ext/xdebug.dll -q
-  - echo "zend_extension=xdebug.dll" >> /c/tools/$PHP_DIR/php.ini
+  - travis_retry wget $XDEBUG -O /c/tools/$PHP_DIR/ext/xdebug.dll -q;
+  - echo "zend_extension=xdebug.dll" >> /c/tools/$PHP_DIR/php.ini;
 
 install:
-#  - travis_retry php composer.phar update --no-interaction --prefer-dist --no-suggest
   - travis_retry composer update --no-interaction --prefer-dist --no-suggest
 
 script: ./vendor/bin/phpunit --coverage-clover=/c/tools/$PHP_DIR/coverage.clover
 
 after_script:
-  - travis_retry wget https://github.com/scrutinizer-ci/ocular/releases/download/1.5.2/ocular.phar
+  - travis_retry wget https://github.com/scrutinizer-ci/ocular/releases/download/1.5.2/ocular.phar -q;
   - php ocular.phar code-coverage:upload --format=php-clover /c/tools/$PHP_DIR/coverage.clover 2>&1

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_install:
   - echo "extension=php_ftp.dll" >> /c/tools/$PHP_DIR/php.ini;
   - echo "extension=php_com_dotnet.dll" >> /c/tools/$PHP_DIR/php.ini;
   - echo "memory_limit=256M" >> /c/tools/$PHP_DIR/php.ini;
-  - choco install composer '"/DEV=c:/tools /PHP="'/c/tools/$PHP_DIR;
+  - choco install composer --ia '"/DEV=c:/tools /PHP="'/c/tools/$PHP_DIR;
   - composer || true;
   - travis_retry wget https://curl.haxx.se/ca/cacert.pem -O /c/tools/cacert.pem -q
   - echo "curl.cainfo=C:\tools\cacert.pem" >> /c/tools/$PHP_DIR/php.ini

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ before_install:
   - echo "extension=php_com_dotnet.dll" >> /c/tools/$PHP_DIR/php.ini;
   - echo "memory_limit=256M" >> /c/tools/$PHP_DIR/php.ini;
   - choco install composer -i;
-  - dir /c/tools || true;
+  - export PATH=/c/ProgramData/ComposerSetup/bin:$PATH;
   - composer || true;
   - travis_retry wget https://curl.haxx.se/ca/cacert.pem -O /c/tools/cacert.pem -q
   - echo "curl.cainfo=C:\tools\cacert.pem" >> /c/tools/$PHP_DIR/php.ini

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
   - echo "extension=php_ftp.dll" >> /c/tools/$PHP_DIR/php.ini
   - echo "extension=php_com_dotnet.dll" >> /c/tools/$PHP_DIR/php.ini
   - echo "memory_limit=256M" >> /c/tools/$PHP_DIR/php.ini
-  - get https://raw.githubusercontent.com/composer/getcomposer.org/d3e09029468023aa4e9dcd165e9b6f43df0a9999/web/installer -O - -q | php --
+  - wget https://raw.githubusercontent.com/composer/getcomposer.org/d3e09029468023aa4e9dcd165e9b6f43df0a9999/web/installer -O - -q | php --
   - travis_retry php composer.phar self-update
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ before_install:
   - echo "zend_extension=xdebug.dll" >> /c/tools/$PHP_DIR/php.ini
 
 install:
-  - travis_retry php composer.phar update --no-interaction --prefer-stable --prefer-dist --no-suggest
+  - travis_retry php composer.phar update --no-interaction --prefer-dist --no-suggest
 
 script: ./vendor/bin/phpunit --coverage-clover=/c/tools/$PHP_DIR/coverage.clover
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_install:
   - echo "extension=php_com_dotnet.dll" >> /c/tools/$PHP_DIR/php.ini
   - echo "memory_limit=256M" >> /c/tools/$PHP_DIR/php.ini
   - wget https://xdebug.org/files/php_xdebug-2.8.0beta1-7.2-vc15-nts-x86_64.dll -O /c/tools/$PHP_DIR/ext/xdebug.dll -q
-  - echo "zend_extension=xdebug.dll" >> /c/tools/$PHP_DIR/php.ini
+#  - echo "zend_extension=xdebug.dll" >> /c/tools/$PHP_DIR/php.ini
 #  - choco install composer
 #  - phpenv config-rm xdebug.ini || true
   - wget https://raw.githubusercontent.com/composer/getcomposer.org/d3e09029468023aa4e9dcd165e9b6f43df0a9999/web/installer -O - -q | php --

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_install:
   - echo "extension=php_ftp.dll" >> /c/tools/$PHP_DIR/php.ini
   - echo "extension=php_com_dotnet.dll" >> /c/tools/$PHP_DIR/php.ini
   - echo "memory_limit=256M" >> /c/tools/$PHP_DIR/php.ini
-  - choco install compose
+  - choco install composer
   - export PATH="C:\Program Files (x86)\ComposerSetup\":$PATH;
   - composer || true
   - travis_retry wget https://curl.haxx.se/ca/cacert.pem -O /c/tools/cacert.pem -q

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,8 @@ before_install:
   - echo "extension=php_com_dotnet.dll" >> /c/tools/$PHP_DIR/php.ini
   - echo "memory_limit=256M" >> /c/tools/$PHP_DIR/php.ini
 #  - choco install composer
+  - travis_retry wget https://curl.haxx.se/ca/cacert.pem -O /c/tools/$PHP_DIR/cacert.pem -q
+  - echo "curl.cainfo=C:\tools\$PHP_DIR\cacert.pem" >> /c/tools/$PHP_DIR/php.ini
   - travis_retry wget https://raw.githubusercontent.com/composer/getcomposer.org/d3e09029468023aa4e9dcd165e9b6f43df0a9999/web/installer -O - -q | php --
   - travis_retry php composer.phar self-update
   - travis_retry wget $XDEBUG -O /c/tools/$PHP_DIR/ext/xdebug.dll -q

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
     - os: windows
       language: sh
       env:
-        - PHP_VERSION=7.2.21
+        - PHP_VERSION=7.2.20
         - PHP_DIR=php72
         - XDEBUG=https://xdebug.org/files/php_xdebug-2.8.0beta1-7.2-vc15-nts-x86_64.dll
     - os: windows

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,8 +39,8 @@ before_install:
   - echo "extension=php_com_dotnet.dll" >> /c/tools/$PHP_DIR/php.ini
   - echo "memory_limit=256M" >> /c/tools/$PHP_DIR/php.ini
 #  - choco install composer
-  - travis_retry wget https://curl.haxx.se/ca/cacert.pem -O /c/tools/$PHP_DIR/cacert.pem -q
-  - echo "curl.cainfo=C:\tools\$PHP_DIR\cacert.pem" >> /c/tools/$PHP_DIR/php.ini
+  - travis_retry wget https://curl.haxx.se/ca/cacert.pem -O /c/tools/cacert.pem -q
+  - echo "curl.cainfo=C:\tools\cacert.pem" >> /c/tools/$PHP_DIR/php.ini
   - travis_retry wget https://raw.githubusercontent.com/composer/getcomposer.org/d3e09029468023aa4e9dcd165e9b6f43df0a9999/web/installer -O - -q | php --
   - travis_retry php composer.phar self-update
   - travis_retry wget $XDEBUG -O /c/tools/$PHP_DIR/ext/xdebug.dll -q

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,8 +47,8 @@ before_install:
 install:
   - travis_retry php composer.phar update --no-interaction --prefer-stable --prefer-dist --no-suggest
 
-script: ./vendor/bin/phpunit --coverage-clover=coverage.clover
+script: ./vendor/bin/phpunit --coverage-clover=/c/tools/$PHP_DIR/coverage.clover
 
 after_script:
   - travis_retry wget https://scrutinizer-ci.com/ocular.phar
-  - php ocular.phar code-coverage:upload --format=php-clover coverage.clover 2>&1
+  - php ocular.phar code-coverage:upload --format=php-clover /c/tools/$PHP_DIR/coverage.clover 2>&1

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,11 +26,11 @@ before_install:
   - echo "memory_limit=256M" >> /c/tools/$PHP_DIR/php.ini
   - wget https://xdebug.org/files/php_xdebug-2.8.0beta1-7.2-vc15-nts-x86_64.dll -O /c/tools/$PHP_DIR/ext/xdebug.dll -q
   - echo "zend_extension=xdebug.dll" >> /c/tools/$PHP_DIR/php.ini
-  - choco install composer
-  #- phpenv config-rm xdebug.ini || true
-  #- wget https://raw.githubusercontent.com/composer/getcomposer.org/d3e09029468023aa4e9dcd165e9b6f43df0a9999/web/installer -O - -q | php --
-  #- travis_retry php composer.phar self-update
-  - travis_retry composer self-update
+#  - choco install composer
+#  - phpenv config-rm xdebug.ini || true
+  - wget https://raw.githubusercontent.com/composer/getcomposer.org/d3e09029468023aa4e9dcd165e9b6f43df0a9999/web/installer -O - -q | php --
+  - travis_retry php composer.phar self-update
+#  - travis_retry composer self-update
 
 install:
   - travis_retry composer update --no-interaction --prefer-stable --prefer-dist --no-suggest

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,10 +29,11 @@ before_install:
   - choco install composer
   #- phpenv config-rm xdebug.ini || true
   #- wget https://raw.githubusercontent.com/composer/getcomposer.org/d3e09029468023aa4e9dcd165e9b6f43df0a9999/web/installer -O - -q | php --
-  - travis_retry php composer.phar self-update
+  #- travis_retry php composer.phar self-update
+  - travis_retry composer self-update
 
 install:
-  - travis_retry php composer.phar update --no-interaction --prefer-stable --prefer-dist --no-suggest
+  - travis_retry composer update --no-interaction --prefer-stable --prefer-dist --no-suggest
 
 script: ./vendor/bin/phpunit --coverage-clover=coverage.clover
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,4 +50,4 @@ script: ./vendor/bin/phpunit --coverage-clover=coverage.clover
 
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar
-  - php ocular.phar code-coverage:upload --format=php-clover coverage.clover 2>&1
+  - php ocular.phar code-coverage:upload --format=php-clover coverage.clover --repository=phpwintools/wmi-scripting  2>&1

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ before_install:
   - echo "extension=php_com_dotnet.dll" >> /c/tools/$PHP_DIR/php.ini
   - echo "memory_limit=256M" >> /c/tools/$PHP_DIR/php.ini
   - choco install composer
-  - export PATH="C:\Program Files (x86)\ComposerSetup\":$PATH;
+  - export PATH=$PATH:";C:\Program Files (x86)\ComposerSetup";
   - composer || true
   - travis_retry wget https://curl.haxx.se/ca/cacert.pem -O /c/tools/cacert.pem -q
   - echo "curl.cainfo=C:\tools\cacert.pem" >> /c/tools/$PHP_DIR/php.ini

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,36 @@
-sudo: required
-dist: xenial
-language: php
-dotnet: 2.2
+matrix:
+  fast_finish: true
+  include:
+    - os: windows
+      language: sh
+      env:
+        - PHP_VERSION=7.2.13
+        - PHP_DIR=php72
 
-php:
-  - '7.1'
-  - '7.2'
-  - '7.3'
+cache:
+  directories:
+    - $HOME/.composer/cache
 
 before_script:
-  - travis_retry composer self-update
-  - travis_retry composer install --no-interaction
+  - choco install php --version $PHP_VERSION -y;
+  - export PATH=/c/tools/$PHP_DIR:$PATH;
+  - echo 'extension_dir="ext"' >> /c/tools/$PHP_DIR/php.ini
+  - echo "extension=php_openssl.dll" >> /c/tools/$PHP_DIR/php.ini;
+  - echo "extension=php_mbstring.dll" >> /c/tools/$PHP_DIR/php.ini
+  - echo "extension=php_pdo_mysql.dll" >> /c/tools/$PHP_DIR/php.ini
+  - echo "extension=php_pdo_sqlite.dll" >> /c/tools/$PHP_DIR/php.ini
+  - echo "extension=php_fileinfo.dll" >> /c/tools/$PHP_DIR/php.ini
+  - echo "extension=php_gd2.dll" >> /c/tools/$PHP_DIR/php.ini
+  - echo "extension=php_ftp.dll" >> /c/tools/$PHP_DIR/php.ini
+  - echo "extension=php_com_dotnet.dll" >> /c/tools/$PHP_DIR/php.ini
+  - echo "memory_limit=256M" >> /c/tools/$PHP_DIR/php.ini
+  - travis_retry php composer.phar self-update
+
+install:
+  - travis_retry php composer.phar update --no-interaction --prefer-stable --prefer-dist --no-suggest
 
 script: ./vendor/bin/phpunit --coverage-clover=coverage.clover
 
-after_script:
-  - wget https://scrutinizer-ci.com/ocular.phar
-  - php ocular.phar code-coverage:upload --format=php-clover coverage.clover 2>&1
+#after_script:
+#  - wget https://scrutinizer-ci.com/ocular.phar
+#  - php ocular.phar code-coverage:upload --format=php-clover coverage.clover 2>&1

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ cache:
   directories:
     - $HOME/.composer/cache
 
-before_script:
+before_install:
   - choco install php --version $PHP_VERSION -y;
   - export PATH=/c/tools/$PHP_DIR:$PATH;
   - echo 'extension_dir="ext"' >> /c/tools/$PHP_DIR/php.ini

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,6 @@ install:
 
 script: ./vendor/bin/phpunit --coverage-clover=coverage.clover
 
-#after_script:
-#  - wget https://scrutinizer-ci.com/ocular.phar
-#  - php ocular.phar code-coverage:upload --format=php-clover coverage.clover 2>&1
+after_script:
+  - wget https://scrutinizer-ci.com/ocular.phar
+  - php ocular.phar code-coverage:upload --format=php-clover coverage.clover 2>&1

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ before_install:
   - export PATH=/c/tools/$PHP_DIR:$PATH;
   - echo 'extension_dir="ext"' >> /c/tools/$PHP_DIR/php.ini
   - echo "extension=php_openssl.dll" >> /c/tools/$PHP_DIR/php.ini;
+  - echo "extension=php_curl.dll" >> /c/tools/$PHP_DIR/php.ini;
   - echo "extension=php_mbstring.dll" >> /c/tools/$PHP_DIR/php.ini
   - echo "extension=php_pdo_mysql.dll" >> /c/tools/$PHP_DIR/php.ini
   - echo "extension=php_pdo_sqlite.dll" >> /c/tools/$PHP_DIR/php.ini
@@ -50,4 +51,4 @@ script: ./vendor/bin/phpunit --coverage-clover=coverage.clover
 
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar
-  - php ocular.phar code-coverage:upload --format=php-clover coverage.clover --repository=phpwintools/wmi-scripting  2>&1
+  - php ocular.phar code-coverage:upload --format=php-clover coverage.clover --repository="phpwintools/wmi-scripting"  2>&1

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,10 @@ cache:
     - $HOME/.composer/cache
 
 before_install:
+  # Install PHP and setup PATH
   - choco install php --version $PHP_VERSION -y;
   - export PATH=/c/tools/$PHP_DIR:$PATH;
+  # Modify configuration
   - echo 'extension_dir="ext"' >> /c/tools/$PHP_DIR/php.ini;
   - echo "extension=php_openssl.dll" >> /c/tools/$PHP_DIR/php.ini;
   - echo "extension=php_curl.dll" >> /c/tools/$PHP_DIR/php.ini;
@@ -38,18 +40,23 @@ before_install:
   - echo "extension=php_ftp.dll" >> /c/tools/$PHP_DIR/php.ini;
   - echo "extension=php_com_dotnet.dll" >> /c/tools/$PHP_DIR/php.ini;
   - echo "memory_limit=256M" >> /c/tools/$PHP_DIR/php.ini;
+  # Install Composer and modify PATH
   - choco install composer -i;
   - export PATH=/c/ProgramData/ComposerSetup/bin:$PATH;
-  - composer || true;
+  # Download CA Bundle and update configuration
   - travis_retry wget https://curl.haxx.se/ca/cacert.pem -O /c/tools/cacert.pem -q
   - echo "curl.cainfo=C:\tools\cacert.pem" >> /c/tools/$PHP_DIR/php.ini
-  - travis_retry wget https://raw.githubusercontent.com/composer/getcomposer.org/d3e09029468023aa4e9dcd165e9b6f43df0a9999/web/installer -O - -q | php --
-  - travis_retry php composer.phar self-update
+#  - travis_retry wget https://raw.githubusercontent.com/composer/getcomposer.org/d3e09029468023aa4e9dcd165e9b6f43df0a9999/web/installer -O - -q | php --
+  # Make sure composer is up-to-date
+  - travis_retry composer self-update
+#  - travis_retry php composer.phar self-update
+  # Download appropriate XDebug and modify configuration
   - travis_retry wget $XDEBUG -O /c/tools/$PHP_DIR/ext/xdebug.dll -q
   - echo "zend_extension=xdebug.dll" >> /c/tools/$PHP_DIR/php.ini
 
 install:
-  - travis_retry php composer.phar update --no-interaction --prefer-dist --no-suggest
+#  - travis_retry php composer.phar update --no-interaction --prefer-dist --no-suggest
+  - travis_retry composer update --no-interaction --prefer-dist --no-suggest
 
 script: ./vendor/bin/phpunit --coverage-clover=/c/tools/$PHP_DIR/coverage.clover
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,8 @@ before_install:
   - echo "extension=php_ftp.dll" >> /c/tools/$PHP_DIR/php.ini;
   - echo "extension=php_com_dotnet.dll" >> /c/tools/$PHP_DIR/php.ini;
   - echo "memory_limit=256M" >> /c/tools/$PHP_DIR/php.ini;
-  - choco install composer --ia '"/DEV=c:/tools /PHP="'/c/tools/$PHP_DIR;
+  - choco install composer -i;
+  - dir /c/tools || true;
   - composer || true;
   - travis_retry wget https://curl.haxx.se/ca/cacert.pem -O /c/tools/cacert.pem -q
   - echo "curl.cainfo=C:\tools\cacert.pem" >> /c/tools/$PHP_DIR/php.ini

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,21 @@ matrix:
     - os: windows
       language: sh
       env:
-        - PHP_VERSION=7.2.13
+        - PHP_VERSION=7.1.25
+        - PHP_DIR=php71
+        - XDEBUG=https://xdebug.org/files/php_xdebug-2.8.0beta1-7.1-vc14-nts-x86_64.dll
+    - os: windows
+      language: sh
+      env:
+        - PHP_VERSION=7.2.21
         - PHP_DIR=php72
+        - XDEBUG=https://xdebug.org/files/php_xdebug-2.8.0beta1-7.2-vc15-nts-x86_64.dll
+    - os: windows
+      language: sh
+      env:
+        - PHP_VERSION=7.3.8
+        - PHP_DIR=php73
+        - XDEBUG=https://xdebug.org/files/php_xdebug-2.8.0beta1-7.3-vc15-nts-x86_64.dll
 
 cache:
   directories:
@@ -25,12 +38,10 @@ before_install:
   - echo "extension=php_com_dotnet.dll" >> /c/tools/$PHP_DIR/php.ini
   - echo "memory_limit=256M" >> /c/tools/$PHP_DIR/php.ini
 #  - choco install composer
-#  - phpenv config-rm xdebug.ini || true
   - wget https://raw.githubusercontent.com/composer/getcomposer.org/d3e09029468023aa4e9dcd165e9b6f43df0a9999/web/installer -O - -q | php --
   - travis_retry php composer.phar self-update
-  - wget https://xdebug.org/files/php_xdebug-2.8.0beta1-7.2-vc15-nts-x86_64.dll -O /c/tools/$PHP_DIR/ext/xdebug.dll -q
+  - wget $XDEBUG -O /c/tools/$PHP_DIR/ext/xdebug.dll -q
   - echo "zend_extension=xdebug.dll" >> /c/tools/$PHP_DIR/php.ini
-#  - travis_retry composer self-update
 
 install:
   - travis_retry php composer.phar update --no-interaction --prefer-stable --prefer-dist --no-suggest

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,7 @@ before_install:
   - echo "extension=php_ftp.dll" >> /c/tools/$PHP_DIR/php.ini
   - echo "extension=php_com_dotnet.dll" >> /c/tools/$PHP_DIR/php.ini
   - echo "memory_limit=256M" >> /c/tools/$PHP_DIR/php.ini
-  - choco install composer
-  - export PATH=$PATH:";C:\Program Files (x86)\ComposerSetup";
+  - choco install composer --ia '"/DEV=c:\tools /PHP="':/c/tools/$PHP_DIR
   - composer || true
   - travis_retry wget https://curl.haxx.se/ca/cacert.pem -O /c/tools/cacert.pem -q
   - echo "curl.cainfo=C:\tools\cacert.pem" >> /c/tools/$PHP_DIR/php.ini

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,8 @@ before_install:
   - echo "extension=php_ftp.dll" >> /c/tools/$PHP_DIR/php.ini
   - echo "extension=php_com_dotnet.dll" >> /c/tools/$PHP_DIR/php.ini
   - echo "memory_limit=256M" >> /c/tools/$PHP_DIR/php.ini
-  - choco install composer /DEV=/c/tools/composer
-  - export PATH=/c/tools/composer:$PATH;
+  - choco install compose
+  - export PATH="C:\Program Files (x86)\ComposerSetup\":$PATH;
   - composer || true
   - travis_retry wget https://curl.haxx.se/ca/cacert.pem -O /c/tools/cacert.pem -q
   - echo "curl.cainfo=C:\tools\cacert.pem" >> /c/tools/$PHP_DIR/php.ini

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,11 @@ before_install:
   - echo "extension=php_ftp.dll" >> /c/tools/$PHP_DIR/php.ini
   - echo "extension=php_com_dotnet.dll" >> /c/tools/$PHP_DIR/php.ini
   - echo "memory_limit=256M" >> /c/tools/$PHP_DIR/php.ini
-  - phpenv config-rm xdebug.ini || true
-  - wget https://raw.githubusercontent.com/composer/getcomposer.org/d3e09029468023aa4e9dcd165e9b6f43df0a9999/web/installer -O - -q | php --
+  - wget https://xdebug.org/files/php_xdebug-2.8.0beta1-7.2-vc15-nts-x86_64.dll -O /c/tools/$PHP_DIR/ext/xdebug.dll -q
+  - echo "zend_extension=xdebug.dll" >> /c/tools/$PHP_DIR/php.ini
+  - choco install composer
+  #- phpenv config-rm xdebug.ini || true
+  #- wget https://raw.githubusercontent.com/composer/getcomposer.org/d3e09029468023aa4e9dcd165e9b6f43df0a9999/web/installer -O - -q | php --
   - travis_retry php composer.phar self-update
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,9 @@ before_install:
   - echo "extension=php_ftp.dll" >> /c/tools/$PHP_DIR/php.ini
   - echo "extension=php_com_dotnet.dll" >> /c/tools/$PHP_DIR/php.ini
   - echo "memory_limit=256M" >> /c/tools/$PHP_DIR/php.ini
-#  - choco install composer
+  - choco install composer
+  - export PATH=/c/tools/composer:$PATH;
+  - composer || true
   - travis_retry wget https://curl.haxx.se/ca/cacert.pem -O /c/tools/cacert.pem -q
   - echo "curl.cainfo=C:\tools\cacert.pem" >> /c/tools/$PHP_DIR/php.ini
   - travis_retry wget https://raw.githubusercontent.com/composer/getcomposer.org/d3e09029468023aa4e9dcd165e9b6f43df0a9999/web/installer -O - -q | php --

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,4 +51,4 @@ script: ./vendor/bin/phpunit --coverage-clover=coverage.clover
 
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar
-  - php ocular.phar code-coverage:upload --format=php-clover coverage.clover --repository="phpwintools/wmi-scripting"  2>&1
+  - php ocular.phar code-coverage:upload --format=php-clover coverage.clover 2>&1

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_install:
   - echo "extension=php_ftp.dll" >> /c/tools/$PHP_DIR/php.ini
   - echo "extension=php_com_dotnet.dll" >> /c/tools/$PHP_DIR/php.ini
   - echo "memory_limit=256M" >> /c/tools/$PHP_DIR/php.ini
-  - choco install composer --ia '"/DEV=c:\tools /PHP="':/c/tools/$PHP_DIR
+  - choco install composer --ia '"/DEV=c:\tools /PHP=c:\tools\"':$PHP_DIR
   - composer || true
   - travis_retry wget https://curl.haxx.se/ca/cacert.pem -O /c/tools/cacert.pem -q
   - echo "curl.cainfo=C:\tools\cacert.pem" >> /c/tools/$PHP_DIR/php.ini

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,9 +39,9 @@ before_install:
   - echo "extension=php_com_dotnet.dll" >> /c/tools/$PHP_DIR/php.ini
   - echo "memory_limit=256M" >> /c/tools/$PHP_DIR/php.ini
 #  - choco install composer
-  - wget https://raw.githubusercontent.com/composer/getcomposer.org/d3e09029468023aa4e9dcd165e9b6f43df0a9999/web/installer -O - -q | php --
+  - travis_retry wget https://raw.githubusercontent.com/composer/getcomposer.org/d3e09029468023aa4e9dcd165e9b6f43df0a9999/web/installer -O - -q | php --
   - travis_retry php composer.phar self-update
-  - wget $XDEBUG -O /c/tools/$PHP_DIR/ext/xdebug.dll -q
+  - travis_retry wget $XDEBUG -O /c/tools/$PHP_DIR/ext/xdebug.dll -q
   - echo "zend_extension=xdebug.dll" >> /c/tools/$PHP_DIR/php.ini
 
 install:
@@ -50,5 +50,5 @@ install:
 script: ./vendor/bin/phpunit --coverage-clover=coverage.clover
 
 after_script:
-  - wget https://scrutinizer-ci.com/ocular.phar
+  - travis_retry wget https://scrutinizer-ci.com/ocular.phar
   - php ocular.phar code-coverage:upload --format=php-clover coverage.clover 2>&1

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_install:
 #  - travis_retry composer self-update
 
 install:
-  - travis_retry composer update --no-interaction --prefer-stable --prefer-dist --no-suggest
+  - travis_retry php composer.phar update --no-interaction --prefer-stable --prefer-dist --no-suggest
 
 script: ./vendor/bin/phpunit --coverage-clover=coverage.clover
 

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
     "require": {
         "php": "^7.1.3",
         "ext-json": "*",
+        "ext-com_dotnet": "*",
         "tightenco/collect": "^5.6",
         "illuminate/contracts": "^5.6"
     },

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -17,11 +17,6 @@
             <directory suffix="Test.php">./tests/Feature</directory>
         </testsuite>
     </testsuites>
-    <groups>
-        <exclude>
-            <group>uses_real_com</group>
-        </exclude>
-    </groups>
     <filter>
         <whitelist processUncoveredFilesFromWhitelist="true">
             <directory suffix=".php">./src</directory>


### PR DESCRIPTION
#1 - This updates the .travis.yml to use a Windows Container so that actual tests using the COM_DOTNET extension can be run (to prove the library ACTUALLY works) and the .scrutinizer.yml to ignore the tests in the group 'uses_real_com'.